### PR TITLE
Fix Workday scraper JavaScript syntax error

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -887,7 +887,7 @@ async def _extract_job_links(
     """
     try:
         links = await page.evaluate(f'''() => {{
-            const elements = document.querySelectorAll("{job_link_selector}");
+            const elements = document.querySelectorAll('{job_link_selector}');
             return Array.from(elements).map(el => el.href);
         }}''')
 


### PR DESCRIPTION
Fixed a syntax error in the _extract_job_links function where the job link selector containing double quotes was being interpolated into a JavaScript string with double quotes, causing a "missing ) after argument list" error.

Changed the querySelectorAll parameter to use single quotes so selectors like [data-automation-id="jobTitle"] are properly escaped when interpolated.