### PR TITLE
Find and open the oldest issue

### DIFF
--- a/scrapers/custom_navigation_scraper.py
+++ b/scrapers/custom_navigation_scraper.py
@@ -95,7 +95,7 @@ class CustomNavigationScraper(BaseScraper):
             return False
 
         # Find next button
-        next_button = await self.tab.query_selector(next_page_selector)
+        next_button = await self.tab.select(next_page_selector)
         if not next_button:
             self.logger.info("No more next button found")
             return False


### PR DESCRIPTION
…craper

The CustomNavigationScraper was using the Playwright API method query_selector(), which doesn't exist in nodriver (or returns None). This caused a TypeError when trying to call get_attribute() on the next button element.

Changed to use tab.select() which is the correct nodriver API method, consistent with all other modern scrapers in the codebase.

Fixes the Virginia scraper TypeError: 'NoneType' object is not callable